### PR TITLE
Exclude .git folder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10067,7 +10067,7 @@
     },
     "packages/ignore": {
       "name": "@gitstart/gitslice-ignore",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "micromatch": "^4.0.5"

--- a/packages/ignore/index.test.ts
+++ b/packages/ignore/index.test.ts
@@ -218,6 +218,19 @@ describe("ignore mode", () => {
       filesToSlice: [],
     });
   });
+
+  it("does not slice .git folder and files", () => {
+    expect(
+      gitslice({
+        mode: "ignore",
+        pathsToIgnore: [],
+        pathsToSlice: [".git"],
+        files: [".git/config", ".git/description", "a"],
+      }),
+    ).toEqual<GitSliceOutput>({
+      filesToSlice: [],
+    });
+  });
 });
 describe("slice mode", () => {
   it("slices everything if no pathsToIgnore", () => {
@@ -441,6 +454,19 @@ describe("slice mode", () => {
       }),
     ).toEqual<GitSliceOutput>({
       filesToSlice: ["a", "a/b", "c", "d/e"],
+    });
+  });
+
+  it("does not slice .git files", () => {
+    expect(
+      gitslice({
+        mode: "slice",
+        pathsToIgnore: [],
+        pathsToSlice: [],
+        files: [".git/config", ".git/description", "a"],
+      }),
+    ).toEqual<GitSliceOutput>({
+      filesToSlice: ["a"],
     });
   });
 });

--- a/packages/ignore/index.ts
+++ b/packages/ignore/index.ts
@@ -48,6 +48,7 @@ const matcher = (files: string[], toMatch: string[], toExclude: string[]) => {
     {
       bash: true,
       dot: true,
+      ignore: [".git", ".git/*"],
     },
   );
 };
@@ -68,6 +69,8 @@ export function gitslice(input: GitSliceInput): GitSliceOutput {
     input.pathsToSlice,
   );
   return {
-    filesToSlice: input.files.filter((file) => !toIgnore.includes(file)),
+    filesToSlice: input.files
+      .filter((file) => !toIgnore.includes(file))
+      .filter((file) => !file.startsWith(".git/")),
   };
 }

--- a/packages/ignore/package.json
+++ b/packages/ignore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gitstart/gitslice-ignore",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Implements the core algorithm to identify what to slice and what to ignore",
   "keywords": [
     "gitslice",


### PR DESCRIPTION
We should exclude the .git folder by default.
Otherwise when slicing, we risk copying over the .git folder from the upstream to the sliced repo.

It started showing up when QA-ing using git slice hooks, specifically when QA-ing the slice mode, as that slices everything by default. I was unable to push as the entire git history of the sliced repo was getting overwritten
