### PR TITLE
update version to 1.13: use d.ts file

### DIFF
--- a/packages/ignore/index.d.ts
+++ b/packages/ignore/index.d.ts
@@ -1,0 +1,36 @@
+ type GitSliceInput = {
+    /**
+     * Use "ignore" when you want to ignore everything by default.
+     * Use "slice" when you want to slice everything by default
+     */
+    mode: "ignore" | "slice";
+    /**
+     * The paths that you want to ensure are sliced
+     * Empty strings are ignored
+     */
+    pathsToSlice: string[];
+    /**
+     * The paths that you want to ensure are ignored
+     * Empty strings are ignored
+     */
+    pathsToIgnore: string[];
+    /**
+     * All the files in the repo, relative to the root folder of the repo
+     */
+    files: ReadonlyArray<string>;
+  };
+  
+   type GitSliceOutput = {
+    /**
+     * All the files that should be pulled into the sliced repo
+     */
+    filesToSlice: string[];
+    /**
+     * All the files that should not be pulled into the sliced repo
+     */
+    filesToIgnore: string[];
+  };
+
+
+  declare function gitslice(input: GitSliceInput): GitSliceOutput;
+  

--- a/packages/ignore/index.d.ts
+++ b/packages/ignore/index.d.ts
@@ -1,36 +1,34 @@
- type GitSliceInput = {
-    /**
-     * Use "ignore" when you want to ignore everything by default.
-     * Use "slice" when you want to slice everything by default
-     */
-    mode: "ignore" | "slice";
-    /**
-     * The paths that you want to ensure are sliced
-     * Empty strings are ignored
-     */
-    pathsToSlice: string[];
-    /**
-     * The paths that you want to ensure are ignored
-     * Empty strings are ignored
-     */
-    pathsToIgnore: string[];
-    /**
-     * All the files in the repo, relative to the root folder of the repo
-     */
-    files: ReadonlyArray<string>;
-  };
-  
-   type GitSliceOutput = {
-    /**
-     * All the files that should be pulled into the sliced repo
-     */
-    filesToSlice: string[];
-    /**
-     * All the files that should not be pulled into the sliced repo
-     */
-    filesToIgnore: string[];
-  };
+type GitSliceInput = {
+  /**
+   * Use "ignore" when you want to ignore everything by default.
+   * Use "slice" when you want to slice everything by default
+   */
+  mode: "ignore" | "slice";
+  /**
+   * The paths that you want to ensure are sliced
+   * Empty strings are ignored
+   */
+  pathsToSlice: string[];
+  /**
+   * The paths that you want to ensure are ignored
+   * Empty strings are ignored
+   */
+  pathsToIgnore: string[];
+  /**
+   * All the files in the repo, relative to the root folder of the repo
+   */
+  files: ReadonlyArray<string>;
+};
 
+type GitSliceOutput = {
+  /**
+   * All the files that should be pulled into the sliced repo
+   */
+  filesToSlice: string[];
+  /**
+   * All the files that should not be pulled into the sliced repo
+   */
+  filesToIgnore: string[];
+};
 
-  declare function gitslice(input: GitSliceInput): GitSliceOutput;
-  
+declare function gitslice(input: GitSliceInput): GitSliceOutput;

--- a/packages/ignore/index.test.ts
+++ b/packages/ignore/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, describe, it } from "vitest";
-import { GitSliceOutput, gitslice } from "./index";
+import { gitslice } from "./index";
 
 const files = [
   "package-lock.json",

--- a/packages/ignore/index.ts
+++ b/packages/ignore/index.ts
@@ -1,38 +1,5 @@
 import micromatch from "micromatch";
 
-type GitSliceInput = {
-  /**
-   * Use "ignore" when you want to ignore everything by default.
-   * Use "slice" when you want to slice everything by default
-   */
-  mode: "ignore" | "slice";
-  /**
-   * The paths that you want to ensure are sliced
-   * Empty strings are ignored
-   */
-  pathsToSlice: string[];
-  /**
-   * The paths that you want to ensure are ignored
-   * Empty strings are ignored
-   */
-  pathsToIgnore: string[];
-  /**
-   * All the files in the repo, relative to the root folder of the repo
-   */
-  files: ReadonlyArray<string>;
-};
-
-export type GitSliceOutput = {
-  /**
-   * All the files that should be pulled into the sliced repo
-   */
-  filesToSlice: string[];
-  /**
-   * All the files that should not be pulled into the sliced repo
-   */
-  filesToIgnore: string[];
-};
-
 const parsePath = (path: string, match: boolean) => {
   const prefix = match ? "" : "!";
   if (path === "/") {

--- a/packages/ignore/package.json
+++ b/packages/ignore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gitstart/gitslice-ignore",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Implements the core algorithm to identify what to slice and what to ignore",
   "keywords": [
     "gitslice",
@@ -23,10 +23,10 @@
   "devDependencies": {
     "@types/micromatch": "^4.0.4"
   },
-  "types": "./index.ts",
+  "types": "./index.d.ts",
   "files": [
     "dist",
-    "index.ts"
+    "index.d.ts"
   ],
   "dependencies": {
     "micromatch": "^4.0.5"


### PR DESCRIPTION
Slack thread that prompted this: https://gitstarthq-workspace.slack.com/archives/C06FHLMGJFK/p1725524626429729

We are encountering a bit of a strange situation that indicates a circular definition if we try to import the types into the .ts file from the .d.ts file, and also the .ts file is not recognizing that the types are being exported.

The idea now is to try to use ver 1.13 on amazon to see if it fixes the issue with deno running typescript checks as mentioned in the thread above.